### PR TITLE
Remove RPM warning and README improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,17 +3,24 @@ RPM packaging of Mapnik for Sailfish
 
 ## Howto build
 
-* Clone this repository
+* Clone this repository into a directory of your choice ${PKGMAPNIK}
 
-* cd into source directory
-
-* build by running 
+* Change into directory where repository is:
 ```
-export SFARCH=armv7hl; mb2 -t SailfishOS-$SFARCH -s ../rpm/mapnik.spec build
+cd ${PKGMAPNIK}
 ```
-in MER SDK. 
 
-* RPMs are under RPMS directory.
+* Select your target (available in /srv/mer/targets) in MerSDK/SailfishSDK ${SFARCH}
+
+* Build by running the following in MerSDK/SailfishSDK:
+```
+mb2 -t ${SFARCH} -s rpm/mapnik.spec apply
+mb2 -t ${SFARCH} -s rpm/mapnik.spec build 
+```
+
+* RPMs will be created in RPMS directory, copy them elsewhere.
+
+* Repeat the `build` step for any other required targets. Note that `apply` is not required, or it will attempt to patch twice.
 
 Please let me know if there are some errors (missing dependencies, for
 example) during building by opening an issue for this repository.

--- a/rpm/mapnik.spec
+++ b/rpm/mapnik.spec
@@ -92,7 +92,6 @@ cp -r deps/mapbox/variant/include/mapbox %{buildroot}/usr/include
 %{_includedir}/mapbox
 %{_libdir}/libmapnik-json.a
 %{_libdir}/libmapnik-wkt.a
-#%{_libdir}/libmapnik.a
 
 %files tools
 %defattr(-, root, root, 0755)


### PR DESCRIPTION
For issue #4 with the exception of executing build outside mapnik directory, otherwise patches won't apply. Didn't realize this until I re-tested.
I'm not experienced with PR's, so forgive omissions, let me know if I can help further.